### PR TITLE
Fix view hiding when using up/down position

### DIFF
--- a/FocusGuideHelper/FocusGuideHelper/FocusGuideHelper.swift
+++ b/FocusGuideHelper/FocusGuideHelper/FocusGuideHelper.swift
@@ -65,8 +65,11 @@ public class FocusGuideHelper: NSObject {
         }
         
         // set constrains
-        focusGuide.centerYAnchor.constraint(equalTo: fromView.centerYAnchor).isActive = true
-        
+        if pos == .up || po == .down {
+            focusGuide.centerXAnchor.constraint(equalTo: fromView.centerXAnchor).isActive = true
+        } else {
+            focusGuide.centerYAnchor.constraint(equalTo: fromView.centerYAnchor).isActive = true
+        }
         // set element target
         focusGuide.preferredFocusEnvironments = [toView]
         

--- a/FocusGuideHelper/FocusGuideHelper/FocusGuideHelper.swift
+++ b/FocusGuideHelper/FocusGuideHelper/FocusGuideHelper.swift
@@ -65,7 +65,7 @@ public class FocusGuideHelper: NSObject {
         }
         
         // set constrains
-        if pos == .up || po == .down {
+        if pos == .up || pos == .down {
             focusGuide.centerXAnchor.constraint(equalTo: fromView.centerXAnchor).isActive = true
         } else {
             focusGuide.centerYAnchor.constraint(equalTo: fromView.centerYAnchor).isActive = true


### PR DESCRIPTION
Issue: 

        guideHelper.addLinkByFocus(from: btn11, to: btn14, inPosition: .right)
        guideHelper.addLinkByFocus(from: btn11, to: btn14, inPosition: .down)
![simulator screen shot - apple tv - 2018-02-09 at 15 35 58](https://user-images.githubusercontent.com/5795989/36023835-a0ff27be-0daf-11e8-9b03-364e09c82d2d.png)

Fixed:

![simulator screen shot - apple tv - 2018-02-09 at 15 36 10](https://user-images.githubusercontent.com/5795989/36023846-a7e3c4e0-0daf-11e8-83d6-8aace30a0e46.png)

At now working guiding in any direction
